### PR TITLE
add testing for message model

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,7 +2,7 @@ class Message < ApplicationRecord
   include ActiveModel::Validations
 
   validates :name, presence: true
-  validates :email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: :create }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, on: :create }
   validates :message, presence: true
   validates :phone_number, presence: true
   validates_uniqueness_of :phone_number
@@ -10,13 +10,23 @@ class Message < ApplicationRecord
   def self.parse_sms(params)
     parsed_message = params.split('&text=')
     parsed_message_contents = parsed_message[1].split('+--+')
+    parsed_message_contents = Message.twitter_present?(parsed_message_contents)
     data = {}
-    data[:name] = parsed_message_contents[0]
+    data[:name] = parsed_message_contents[0].gsub('+', ' ')
     data[:twitter] = parsed_message_contents[1].sub('%C2%A1', '@')
     data[:email] = parsed_message_contents[2].sub('%C2%A1', '@')
     data[:message] = parsed_message_contents[3].split('&')[0].gsub('+', ' ')
     data[:phone_number] = parsed_message[0].split('=')[1].gsub('&to', '')
     
+    data
+  end
+
+  def self.twitter_present?(data)
+    if data[1].sub('%C2%A1', '@').match?(URI::MailTo::EMAIL_REGEXP)
+      data[3] = data[2] 
+      data[2] = data[1]
+      data[1] = ''
+    end
     data
   end
 

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,7 +1,99 @@
 require 'test_helper'
 
 class MessageTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  def test_validate_email_presence
+    message = Message.new(name: 'Joe Schmoe', message: 'Test message', phone_number: '12122222222')
+    assert_not message.save, "Message requires an email"
+  end
+
+  def test_validate_name_presence
+    message = Message.new(message: 'Test message', phone_number: '12122222222', email: 'test@test.com')
+    assert_not message.save, "Message requires a name"
+  end
+
+  def test_validate_message_presence
+    message = Message.new(phone_number: '12122222222', email: 'test@test.com', name: 'Joe Schmoe')
+    assert_not message.save, "Message requires a message"
+  end
+
+  def test_validate_phone_presence
+    message = Message.new(message: 'Test message', email: 'test@test.com', name: 'Joe Schmoe')
+    assert_not message.save, "Message requires a phone number"
+  end
+
+  def test_validate_email_format_correct
+    message = Message.new(message: 'Test message', email: 'test@test.com', name: 'Joe Schmoe', phone_number: '12122222222')
+    assert message.save
+  end
+
+  def test_validate_email_format_incorrect
+    message = Message.new(message: 'Test message', email: 'not correct format', name: 'Joe Schmoe', phone_number: '12122222222')
+    assert_not message.save, "Email must be in correct format"
+  end
+
+  def test_parse_sms_class_method_with_one_word_name
+    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+--+Twitter+--+test%C2%A1test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
+    expected_hash = {
+      :name => 'Joe', 
+      :twitter => 'Twitter', 
+      :email => 'test@test.com', 
+      :phone_number => '972587889999',
+      :message => 'this is a great idea'
+    }
+    actual_hash = Message.parse_sms(params)
+    assert_equal expected_hash, actual_hash
+  end
+
+  def test_parse_sms_class_method_with_two_word_name
+    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+Schmoe+--+Twitter+--+test%C2%A1test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
+    expected_hash = {
+      :name => 'Joe Schmoe', 
+      :twitter => 'Twitter', 
+      :email => 'test@test.com', 
+      :phone_number => '972587889999',
+      :message => 'this is a great idea'
+    }
+    actual_hash = Message.parse_sms(params)
+    assert_equal expected_hash, actual_hash
+  end
+
+  def test_parse_sms_class_method_with_twitter_no_at_symbol
+    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+Schmoe+--+Twitter+--+test%C2%A1test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
+    expected_hash = {
+      :name => 'Joe Schmoe', 
+      :twitter => 'Twitter', 
+      :email => 'test@test.com', 
+      :phone_number => '972587889999',
+      :message => 'this is a great idea'
+    }
+    actual_hash = Message.parse_sms(params)
+    assert_equal expected_hash, actual_hash
+  end
+
+  def test_parse_sms_class_method_with_twitter_at_symbol
+    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+Schmoe+--+%C2%A1Twitter+--+test%C2%A1test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
+    expected_hash = {
+      :name => 'Joe Schmoe', 
+      :twitter => '@Twitter', 
+      :email => 'test@test.com', 
+      :phone_number => '972587889999',
+      :message => 'this is a great idea'
+    }
+    actual_hash = Message.parse_sms(params)
+    assert_equal expected_hash, actual_hash
+  end
+
+  def test_parse_sms_class_method_with_no_twitter_value
+    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+Schmoe+--+test%C2%A1test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
+    expected_hash = {
+      :name => 'Joe Schmoe', 
+      :twitter => '', 
+      :email => 'test@test.com', 
+      :phone_number => '972587889999',
+      :message => 'this is a great idea'
+    }
+    actual_hash = Message.parse_sms(params)
+    assert_equal expected_hash, actual_hash
+  end
 end


### PR DESCRIPTION
Add testing for `Message`, which as a result revealed an issue when a user does not submit an optional Twitter handle, so created a new method to address that along with a test. 