### PR TITLE
refactor to use decode method

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 2019_11_04_083700) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["email"], name: "index_admin_users_on_email", unique: true
+    t.index ["email"], name: "index_admin_users_on_email"
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -33,7 +33,7 @@ class MessageTest < ActiveSupport::TestCase
   end
 
   def test_parse_sms_class_method_with_one_word_name
-    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+--+Twitter+--+test%C2%A1test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
+    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+--+Twitter+--+test%40test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
     expected_hash = {
       :name => 'Joe', 
       :twitter => 'Twitter', 
@@ -46,7 +46,7 @@ class MessageTest < ActiveSupport::TestCase
   end
 
   def test_parse_sms_class_method_with_two_word_name
-    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+Schmoe+--+Twitter+--+test%C2%A1test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
+    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+Schmoe+--+Twitter+--+test%40test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
     expected_hash = {
       :name => 'Joe Schmoe', 
       :twitter => 'Twitter', 
@@ -59,7 +59,7 @@ class MessageTest < ActiveSupport::TestCase
   end
 
   def test_parse_sms_class_method_with_twitter_no_at_symbol
-    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+Schmoe+--+Twitter+--+test%C2%A1test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
+    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+Schmoe+--+Twitter+--+test%40test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
     expected_hash = {
       :name => 'Joe Schmoe', 
       :twitter => 'Twitter', 
@@ -72,7 +72,7 @@ class MessageTest < ActiveSupport::TestCase
   end
 
   def test_parse_sms_class_method_with_twitter_at_symbol
-    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+Schmoe+--+%C2%A1Twitter+--+test%C2%A1test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
+    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+Schmoe+--+%40Twitter+--+test%40test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
     expected_hash = {
       :name => 'Joe Schmoe', 
       :twitter => '@Twitter', 
@@ -85,7 +85,7 @@ class MessageTest < ActiveSupport::TestCase
   end
 
   def test_parse_sms_class_method_with_no_twitter_value
-    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+Schmoe+--+test%C2%A1test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
+    params = "msisdn=972587889999&to=972587889999&messageId=160000028ACCEB69&text=Joe+Schmoe+--+test%40test.com+--+this+is+a+great+idea&type=text&keyword=JOE&api-key=999999&message-timestamp=2019-11-01+13%3A02%3A29"
     expected_hash = {
       :name => 'Joe Schmoe', 
       :twitter => '', 


### PR DESCRIPTION
Instead of manually decoding the string, use `CGI::unescape` to decode, avoiding decoding errors in production